### PR TITLE
fix linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(MATRIXTRAILS_SOURCES src/column.cpp
                          src/main.cpp
                          src/matrixtrails.cpp)
 
-set(DEPLIBS ${SOIL_LIBRARIES})
+set(DEPLIBS ${SOIL_LIBRARY})
 
 build_addon(screensaver.matrixtrails MATRIXTRAILS DEPLIBS)
 

--- a/FindSOIL.cmake
+++ b/FindSOIL.cmake
@@ -1,7 +1,7 @@
 find_path(SOIL_INCLUDE_DIRS SOIL/SOIL.h)
-find_library(SOIL_LIBRARIES NAMES SOIL)
+find_library(SOIL_LIBRARY NAMES SOIL)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SOIL DEFAULT_MSG SOIL_INCLUDE_DIRS SOIL_LIBRARIES)
+find_package_handle_standard_args(SOIL DEFAULT_MSG SOIL_INCLUDE_DIRS SOIL_LIBRARY)
 
-mark_as_advanced(SOIL_INCLUDE_DIRS SOIL_LIBRARIES)
+mark_as_advanced(SOIL_INCLUDE_DIRS SOIL_LIBRARY)


### PR DESCRIPTION
Without this patch the addon binary is linked against

 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.1]

With this patch this warning during cmake configure is fixed:

-- Found SOIL: /home/bernd/buildroot/br2_kodi16/output/host/usr/x86_64-buildroot-linux-uclibc/sysroot/usr/include
-- MATRIXTRAILS_VERSION=1.0.0
-- Configuring done
WARNING: Target "screensaver.matrixtrails" requests linking to directory "/home/bernd/buildroot/br2_kodi16/output/host/usr/x86_64-buildroot-linux-uclibc/sysroot/usr/lib".  Targets may link only to libraries.  CMake is dropping the item.
-- Generating done

and the binary is linked against

 0x0000000000000001 (NEEDED)             Shared library: [libGLU.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libGL.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libSOIL.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.1]