### PR TITLE
Rename find-package(kodi) to Kodi and get addon.xml inline with other add-ons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(SOIL REQUIRED)
 
 include(ExternalProject)

--- a/screensaver.matrixtrails/addon.xml.in
+++ b/screensaver.matrixtrails/addon.xml.in
@@ -9,11 +9,10 @@
   </requires>
   <extension
     point="xbmc.ui.screensaver"
-    library_linux="screensaver.matrixtrails.so"
-    library_osx="screensaver.matrixtrails.dylib"/>
+    library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <summary>Matrix trails screensaver</summary>
     <description>Matrix trails screensaver</description>
-    <platform>linux osx</platform>
+    <platform>@PLATFORM@</platform>
   </extension>
 </addon>

--- a/screensaver.matrixtrails/addon.xml.in
+++ b/screensaver.matrixtrails/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.matrixtrails"
-  version="1.0.0"
+  version="1.1.0"
   name="Matrix trails"
   provider-name="spiff">
   <requires>


### PR DESCRIPTION
Package renaming is need after https://github.com/xbmc/xbmc/pull/9750 goes in.
The rest is to bring xml files up to par.