### PR TITLE
[screensaver.matrixtrails] 2.3.0

### DIFF
--- a/screensaver.matrixtrails/addon.xml.in
+++ b/screensaver.matrixtrails/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.matrixtrails"
-  version="2.2.1"
+  version="2.3.0"
   name="Matrix trails"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required