### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This is a [Kodi](https://kodi.tv) screensaver addon, with the "digital rain" effect, as seen on the computer monitors in "The Matrix".
 
-![screenshot](https://raw.githubusercontent.com/xbmc/screensaver.matrixtrails/Matrix/screensaver.matrixtrails/resources/fanart.jpg)
+![screenshot](https://raw.githubusercontent.com/xbmc/screensaver.matrixtrails/Nexus/screensaver.matrixtrails/resources/fanart.jpg)
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build and run tests](https://github.com/xbmc/screensaver.matrixtrails/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/xbmc/screensaver.matrixtrails/actions/workflows/build.yml)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.screensaver.matrixtrails?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=45&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/screensaver.matrixtrails/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fscreensaver.matrixtrails/branches/)
+[![Build and run tests](https://github.com/xbmc/screensaver.matrixtrails/actions/workflows/build.yml/badge.svg?branch=Nexus)](https://github.com/xbmc/screensaver.matrixtrails/actions/workflows/build.yml)
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.screensaver.matrixtrails?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=45&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/screensaver.matrixtrails/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fscreensaver.matrixtrails/branches/)
 
 ## Build instructions
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
   branches:
     include:
     - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/screensaver.matrixtrails/addon.xml.in
+++ b/screensaver.matrixtrails/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.matrixtrails"
-  version="2.6.0"
+  version="20.0.0"
   name="Matrix trails"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.